### PR TITLE
Fix console websocket not connecting

### DIFF
--- a/components/pentest-console.tsx
+++ b/components/pentest-console.tsx
@@ -16,7 +16,7 @@ export default function PentestConsole() {
   const [isConnecting, setIsConnecting] = useState(false)
   const consoleRef = useRef<HTMLDivElement>(null)
 
-  const { status, send } = useWebSocket({
+  const { status, send, connect } = useWebSocket({
     url: "ws://localhost:8080/ws/console",
     onOpen: () => {
       console.log("Console WebSocket connected")
@@ -85,8 +85,9 @@ export default function PentestConsole() {
         content: "Connecting to console...",
         timestamp: new Date().toISOString(),
       })
+      connect()
     }
-  }, [credentials])
+  }, [credentials, connect])
 
   const sendCommand = async (command: string) => {
     if (!credentials?.host || !credentials?.username || !credentials?.password) {


### PR DESCRIPTION
## Summary
- fix websocket connection for PentestConsole by calling `connect`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683ff2dc36e0832babf2d49ba9386b0e